### PR TITLE
Updated to ssr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     - `clickSecondaryButton` (on secondary button click)
     - `clickLabel` (on label click)
 
-[1.0.2]: https://github.com/TODOvue/todovue-card/pull/5/files
+[1.0.2]: https://github.com/TODOvue/todovue-card/pull/6/files
 [1.0.1]: https://github.com/TODOvue/todovue-card/pull/4/files
 [1.0.0]: https://github.com/TODOvue/todovue-card/pull/3/files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `@todovue/tv-card` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.0.2] - 2025-10-17
+### 🛠️ Changed
+- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
+- CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-card.css` file optimized for SSR/Nuxt.
+- Changed node-version to workflows release.yml to 20.
+
+### ✨ Added
+- Plugin installation support: `app.use(TvLabel)` or `app.use(TvLabelPlugin)`.
+- Explicit export of the style file: `import '@todovue/tv-label/style.css'`.
+- Documentation for usage in SSR and Nuxt 3 applications.
 
 ## [1.0.1] - 2025-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,5 +36,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     - `clickSecondaryButton` (on secondary button click)
     - `clickLabel` (on label click)
 
+[1.0.2]: https://github.com/TODOvue/todovue-card/pull/5/files
 [1.0.1]: https://github.com/TODOvue/todovue-card/pull/4/files
 [1.0.0]: https://github.com/TODOvue/todovue-card/pull/3/files

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "dev": "vite",
@@ -56,9 +56,9 @@
   },
   "devDependencies": {
     "@todovue/tv-demo": "^1.0.0",
-    "@vitejs/plugin-vue": "^5.0.0",
+    "@vitejs/plugin-vue": "^6.0.0",
     "sass": "^1.0.0",
-    "vite": "^6.0.0",
+    "vite": "^7.0.0",
     "vite-plugin-css-injected-by-js": "^3.0.0",
     "vite-plugin-dts": "^4.0.0"
   }

--- a/src/components/TvCard.vue
+++ b/src/components/TvCard.vue
@@ -1,6 +1,6 @@
 <script setup>
-import TvButton from "@todovue/tv-button";
-import TvLabel from "@todovue/tv-label";
+import { TvButton } from "@todovue/tv-button";
+import { TvLabel } from "@todovue/tv-label";
 import useCard from "../composable/useCard";
 
 const props = defineProps({
@@ -65,6 +65,4 @@ const { handleClickLabel, handleClick, handleSecondaryClick, card } = useCard(pr
   </div>
 </template>
 
-<style lang="scss">
-  @use "../assets/scss/style.scss";
-</style>
+<style lang="scss" src="../assets/scss/style.scss"></style>

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -1,5 +1,5 @@
 <script setup>
-import TvDemo from '@todovue/tv-demo';
+import { TvDemo } from '@todovue/tv-demo';
 import { defineAsyncComponent } from 'vue';
 
 const TvCard = defineAsyncComponent(() => import('../components/TvCard.vue'));
@@ -15,6 +15,6 @@ import { demos } from "../utils/mocks.js";
     npm-install="@todovue/tv-card"
     source-link="https://github.com/TODOvue/tv-card"
     url-clone="https://github.com/TODOvue/tv-card.git"
-    version="1.0.0"
+    version="1.0.2"
   />
 </template>

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,4 +1,14 @@
 import TvCard from './components/TvCard.vue'
 
+(TvCard as any).install = (app: any) => {
+  app.component('TvCard', TvCard)
+};
+
+export const TvCardPlugin = {
+  install(app: any) {
+    app.component('TvCard', TvCard)
+  }
+}
+
 export { TvCard }
 export default TvCard

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,4 @@
 import { createApp } from 'vue'
-import './style.css'
 import TvCard from './demo/Demo.vue'
-import 'github-markdown-css';
 
 createApp(TvCard).mount('#tv-card')

--- a/src/utils/demos/default.vue
+++ b/src/utils/demos/default.vue
@@ -7,7 +7,7 @@
 
 <script setup>
 import { ref } from 'vue';
-import TvCard from '@todovue/tv-card';
+import { TvCard } from '@todovue/tv-card';
 
 const configCard = ref({
   title: 'Create Vue.js',

--- a/src/utils/demos/withCustomColors.vue
+++ b/src/utils/demos/withCustomColors.vue
@@ -9,7 +9,7 @@
 
 <script setup>
 import { ref } from 'vue';
-import TvCard from '@todovue/tv-card';
+import { TvCard } from '@todovue/tv-card';
 
 const configCard = ref({
   title: 'Write Vue.js',

--- a/src/utils/demos/withLabels.vue
+++ b/src/utils/demos/withLabels.vue
@@ -8,7 +8,7 @@
 
 <script setup>
 import { ref } from 'vue';
-import TvCard from '@todovue/tv-card';
+import { TvCard } from '@todovue/tv-card';
 
 const configCard = ref({
   title: 'Write JavaScript',

--- a/src/utils/demos/withMultipleLabels.vue
+++ b/src/utils/demos/withMultipleLabels.vue
@@ -8,7 +8,7 @@
 
 <script setup>
 import { ref } from 'vue';
-import TvCard from '@todovue/tv-card';
+import { TvCard } from '@todovue/tv-card';
 
 const configCard = ref({
   title: 'Write JavaScript',

--- a/src/utils/demos/withTwoButtons.vue
+++ b/src/utils/demos/withTwoButtons.vue
@@ -9,7 +9,7 @@
 
 <script setup>
 import { ref } from 'vue';
-import TvCard from '@todovue/tv-card';
+import { TvCard } from '@todovue/tv-card';
 
 const configCard = ref({
   title: 'Design Web',

--- a/src/utils/mocks.js
+++ b/src/utils/mocks.js
@@ -256,4 +256,4 @@ export const demos = [
     },
     html: WithMultipleLabels,
   },
-];;
+];

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
     }
     : {
       lib: {
-        entry: "src/components/TvCard.vue",
+        entry: "src/entry.ts",
         name: "TvCard",
         fileName: format => `tv-card.${format}.js`,
         formats: ["es", "cjs"]

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,7 +30,8 @@ export default defineConfig({
         output: {
           globals: {
             vue: "Vue"
-          }
+          },
+          exports: 'named'
         }
       }
     },


### PR DESCRIPTION
## [1.0.2] - 2025-10-17
### 🛠️ Changed
- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
- CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-card.css` file optimized for SSR/Nuxt.
- Changed node-version to workflows release.yml to 20.

### ✨ Added
- Plugin installation support: `app.use(TvLabel)` or `app.use(TvLabelPlugin)`.
- Explicit export of the style file: `import '@todovue/tv-label/style.css'`.
- Documentation for usage in SSR and Nuxt 3 applications.