### PR TITLE
Fix position of title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@todovue/tv-card` will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.4] - 2025-11-13
+### 🐛 Fixed
+- Fixed position of title in card when the title is long and wraps into multiple lines.
+
 ## [1.0.3] - 2025-11-13
 ### 🐛 Fixed
 - Fixed styles for dark and light mode in the library build.

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -73,11 +73,12 @@
 
       & .tv-card-title {
         border-radius: 30px 30px 0 0;
-        position: absolute;
+        position: relative;
         width: 85%;
-        padding: 12px 0;
+        padding: 12px 15px;
         text-align: center;
-        top: -50px;
+        margin-top: -70px;
+        margin-bottom: 0;
       }
 
       & .tv-card-label {

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -15,6 +15,6 @@ import { demos } from './utils/mocks.js';
     npm-install="@todovue/tv-card"
     source-link="https://github.com/TODOvue/tv-card"
     url-clone="https://github.com/TODOvue/tv-card.git"
-    version="1.0.3"
+    version="1.0.4"
   />
 </template>


### PR DESCRIPTION
## [1.0.4] - 2025-11-13
### 🐛 Fixed
- Fixed position of title in card when the title is long and wraps into multiple lines.